### PR TITLE
Bugfix date(): Argument #2 ($timestamp) must be of type ?int, string given

### DIFF
--- a/mod_eiko_unwetter.php
+++ b/mod_eiko_unwetter.php
@@ -90,7 +90,7 @@ $jsondata = $lines;
 $jsondata = preg_replace('/([^\\\])":([0-9]{10,})(,|})/', '$1":"$2"$3', $jsondata); // PHP 5.3 fix !!!!
 $json = json_decode($jsondata, true);
 
-$time = date('d.m.Y', substr($json['time'], 0, -3)).' - '.date('H:i', substr($json['time'], 0, -3)).' Uhr'; 
+$time = date('d.m.Y', (int)substr($json['time'], 0, -3)).' - '.date('H:i', (int)substr($json['time'], 0, -3)).' Uhr';
 $copyright = $json['copyright'];
 $arr = $json['warnings'];
 $vorabinformation_arr = $json['vorabInformation'];


### PR DESCRIPTION
Delete Error of:
date(): Argument #2 ($timestamp) must be of type ?int, string given
with add of (int)

The Code is from: https://forum.joomla.de/thread/22066-php-fehler/?postID=165829#post165829